### PR TITLE
[BUGFIX] Fix IpAdressHelper for FASTCGI

### DIFF
--- a/Classes/ExpressionLanguage/PidParameterRootlineContainsPidConditionFunctionsProvider.php
+++ b/Classes/ExpressionLanguage/PidParameterRootlineContainsPidConditionFunctionsProvider.php
@@ -42,7 +42,6 @@ class PidParameterRootlineContainsPidConditionFunctionsProvider implements Expre
             int $comparePid,
             bool $additionallyCheckCurrentRootline = false
         ) {
-
             /* If current rootline should be checked do that first and return if successful */
             if ($additionallyCheckCurrentRootline) {
                 /* Rootline on current page */

--- a/Classes/Helper/IpAddressHelper.php
+++ b/Classes/Helper/IpAddressHelper.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Remind\RmndUtil\Helper;
 
-use function filter_input;
 use function gethostbyname;
-
-use const INPUT_SERVER;
 
 /**
  * Description of IpAddressHelper
@@ -20,12 +17,12 @@ class IpAddressHelper
      */
     public function getRemoteAddr(): string
     {
-        $address = filter_input(INPUT_SERVER, 'REMOTE_ADDR') ?? '';
+        $address = isset($_SERVER['REMOTE_ADDR']) ? filter_var($_SERVER['REMOTE_ADDR']) : '';
 
-        if (!empty(filter_input(INPUT_SERVER, 'TYPO3_DB'))) {
-            $address = filter_input(INPUT_SERVER, 'HTTP_CLIENT_IP') ?? '';
-        } elseif (!empty(filter_input(INPUT_SERVER, 'HTTP_X_FORWARDED_FOR'))) {
-            $address = filter_input(INPUT_SERVER, 'HTTP_X_FORWARDED_FOR') ?? '';
+        if (!empty($_SERVER['TYPO3_DB'])) {
+            $address = isset($_SERVER['HTTP_CLIENT_IP']) ? filter_var($_SERVER['HTTP_CLIENT_IP']) : '';
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            $address = filter_var($_SERVER['HTTP_X_FORWARDED_FOR']) ?? '';
         }
 
         return $address;


### PR DESCRIPTION
filter_input() doesn't work with INPUT_SERVER when you use FASTCGI. FPM isn't affected.

See https://www.php.net/manual/en/function.filter-input.php#127415 or https://stackoverflow.com/questions/25232975/php-filter-inputinput-server-request-method-returns-null